### PR TITLE
Wrapping each element of the the row in quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-csv",
-  "version": "1.0.3-RC1",
+  "version": "1.0.4-RC1",
   "description": "Build CSV files on the fly basing on Array/literal object of data ",
   "main": "index.js",
   "jsnext:main": "src/index.js",

--- a/src/core.js
+++ b/src/core.js
@@ -19,7 +19,7 @@ export const jsons2arrays = (jsons, headers) => {
 };
 
 export const joiner = ((data,separator = ',') =>
- data.map((row, index) => row.join(separator)).join(`\n`)
+ data.map((row, index) => row.map((element) => "\"" + element + "\"").join(separator)).join(`\n`)
 );
 
 export const arrays2csv = ((data, headers, separator) =>

--- a/test/coreSpec.js
+++ b/test/coreSpec.js
@@ -206,20 +206,7 @@ describe(`core::string2csv`, () =>{
 describe(`core::toCSV`, () =>{
   let fixtures;
   beforeEach(() => {
-   fixtures = {string:'
-               
-               
-               
-               
-               
-               
-               
-               
-               
-               
-               
-               
-               y', arrays:[[],[]],jsons:[{}, {}]};
+   fixtures = {string:'Xy', arrays:[[],[]],jsons:[{}, {}]};
   });
   it(`requires one argument at least`, () => {
      expect(() => toCSV()).toThrow();

--- a/test/coreSpec.js
+++ b/test/coreSpec.js
@@ -152,7 +152,7 @@ describe(`core::arrays2csv`, () => {
   it(`renders  CSV headers whenever it was given `, () => {
     const headers = [`X`, `Y`];
     const firstLineOfCSV = arrays2csv(fixtures, headers).split(`\n`)[0];
-    expect(firstLineOfCSV).toEqual(headers.join(`,`));
+    expect(firstLineOfCSV).toEqual("X","Y");
   });
 });
 
@@ -181,8 +181,8 @@ describe(`core::jsons2csv`, () => {
    let fixtures =[{X:'12', Y:'bb'}, {Y:'ee', X:'55'}]
    const headers = ['Y', 'X', 'Z'];
    const actual = jsons2csv(fixtures, headers);
-   expect(actual.startsWith(headers.join(`,`))).toBeTruthy();
-   expect(actual.endsWith(`ee,55,`)).toBeTruthy();
+   expect(actual.startsWith("Y","X","Z")).toBeTruthy();
+   expect(actual.endsWith(`"ee","55",""`)).toBeTruthy();
 
  });
 

--- a/test/coreSpec.js
+++ b/test/coreSpec.js
@@ -146,7 +146,7 @@ describe(`core::arrays2csv`, () => {
   it(`converts Array of arrays to string in CSV format`, () => {
     const actual = arrays2csv(fixtures);
     expect(actual).toBeA('string');
-    expect(actual.split(`\n`).join(`|`)).toEqual(`a,b|c,d`);
+    expect(actual.split(`\n`).join(`|`)).toEqual(`"a","b"|"c","d"`);
   });
 
   it(`renders  CSV headers whenever it was given `, () => {
@@ -173,7 +173,7 @@ describe(`core::jsons2csv`, () => {
 
             const actual = jsons2csv(fixtures);
             const expectedHeaders = ['X', 'Y'];
-            const expected = `${expectedHeaders.join(`,`)}|88,97|77,99`;
+            const expected = `"X","Y"|"88","97"|"77","99"`;
    expect(actual).toBeA('string');
    expect(actual.split(`\n`).join(`|`)).toEqual(expected);
  });
@@ -199,14 +199,27 @@ describe(`core::string2csv`, () =>{
 
   it(`prepends headers at the top of input`, () => {
     const headers =[`X`, `Y`];
-    expect(string2csv(fixtures, headers)).toEqual(`${headers.join(`,`)}\n${fixtures}`);
+    expect(string2csv(fixtures, headers)).toEqual(`"X","Y"\n${fixtures}`);
   });
 });
 
 describe(`core::toCSV`, () =>{
   let fixtures;
   beforeEach(() => {
-   fixtures = {string:'Xy', arrays:[[],[]],jsons:[{}, {}]};
+   fixtures = {string:'
+               
+               
+               
+               
+               
+               
+               
+               
+               
+               
+               
+               
+               y', arrays:[[],[]],jsons:[{}, {}]};
   });
   it(`requires one argument at least`, () => {
      expect(() => toCSV()).toThrow();

--- a/test/coreSpec.js
+++ b/test/coreSpec.js
@@ -152,7 +152,7 @@ describe(`core::arrays2csv`, () => {
   it(`renders  CSV headers whenever it was given `, () => {
     const headers = [`X`, `Y`];
     const firstLineOfCSV = arrays2csv(fixtures, headers).split(`\n`)[0];
-    expect(firstLineOfCSV).toEqual("X","Y");
+    expect(firstLineOfCSV).toEqual(`"X","Y"`);
   });
 });
 
@@ -181,7 +181,7 @@ describe(`core::jsons2csv`, () => {
    let fixtures =[{X:'12', Y:'bb'}, {Y:'ee', X:'55'}]
    const headers = ['Y', 'X', 'Z'];
    const actual = jsons2csv(fixtures, headers);
-   expect(actual.startsWith("Y","X","Z")).toBeTruthy();
+   expect(actual.startsWith(`"Y","X","Z"`)).toBeTruthy();
    expect(actual.endsWith(`"ee","55",""`)).toBeTruthy();
 
  });
@@ -199,7 +199,7 @@ describe(`core::string2csv`, () =>{
 
   it(`prepends headers at the top of input`, () => {
     const headers =[`X`, `Y`];
-    expect(string2csv(fixtures, headers)).toEqual(`"X","Y"\n${fixtures}`);
+    expect(string2csv(fixtures, headers)).toEqual(`X,Y\n${fixtures}`);
   });
 });
 


### PR DESCRIPTION
Commas inside of an element were not supported as the element in the data source wasn't being wrapped in quotes. Wrapping the element in quotes before joining should resolve the problem.