### PR TITLE
Add rendered link ref to expose it

### DIFF
--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -26,6 +26,7 @@ class CSVLink extends React.Component {
     const {data, headers, separator, filename, children , ...rest} = this.props;
     return (
       <a download={filename} {...rest}
+         ref={link => (this.link = link)}
          href={this.buildURI(data, headers, separator)}>
         {children}
       </a>


### PR DESCRIPTION
Hi!

It would be nice to expose rendered link element from CSVLink to be able to get access to its methods. Should I provide a use case which requires this improvement?