### PR TITLE
Conditionally handle IE11 in 'Download' component

### DIFF
--- a/src/components/Download.js
+++ b/src/components/Download.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {buildURI} from '../core';
+import { buildURI, toCSV } from '../core';
 import {
    defaultProps as commonDefaultProps,
    propTypes as commonPropTypes} from '../metaProps';
@@ -29,11 +29,21 @@ class CSVDownload extends React.Component {
     return buildURI(...arguments);
   }
 
+  toCSV() {
+    return toCSV(...arguments);
+  }
+
   componentDidMount(){
-    const {data, headers, separator, uFEFF, target, specs, replace} = this.props;
-    this.state.page = window.open(
-        this.buildURI(data, uFEFF, headers, separator), target, specs, replace
-    );
+    const {data, headers, separator, uFEFF, target, specs, replace, filename} = this.props;
+
+    if (window.navigator.msSaveOrOpenBlob) {
+      //In IE11 this method will trigger the file download
+      let blob = new Blob([this.toCSV(data, headers, separator)]);
+      window.navigator.msSaveBlob(blob, filename);
+
+    } else {
+      this.state.page = window.open(this.buildURI(data, uFEFF, headers, separator), target, specs, replace);
+    }
   }
 
   getWindow() {


### PR DESCRIPTION
### Description
Currently the `Download.js` component does not work on IE11.
Instead of downloading the file, it asks the user to choose an app to open the `blob` file.

### Changes
Update the `componentDidMount()` method in `Download.js` to check if `window.navigator` has a `msSaveOrOpenBlob` method. This method should only be available on IE so it shouldn't other users.

If `msSaveOrOpenBlob` exists, we use the `msSaveBlob` to download the file.
This functionality should be consistent with `Link.js` component.

### Steps to Reproduce
I'm able to reproduce this consistently using IE11 on Windows 10.

1. Have the `Download.js` mount after a specific action (this should trigger the file download to begin).
2.  `componentDidMount()` in the `Download.js` component triggers `window.open` which opens a new window.
3. The new window should result in a file download, but instead users are prompted to `allow this website to open an app`.

![app_prompt](https://user-images.githubusercontent.com/4389490/45114921-4f27a900-b11c-11e8-9d98-ab0b8c9d53a6.png)

4. If user clicks `Allow` they are prompted to choose an app to open the `blob` file.

![blob_app_selection](https://user-images.githubusercontent.com/4389490/45114979-8302ce80-b11c-11e8-86d0-2f035689fba7.png)

5. Searching the Windows Store for an app returns no results.

![app_store_search](https://user-images.githubusercontent.com/4389490/45115031-ae85b900-b11c-11e8-90d2-4ffa126305f4.png)

